### PR TITLE
fix: proper ui load with latest rc, remove old root client py call, add tutorial ref

### DIFF
--- a/worlds/mario_kart_double_dash/__init__.py
+++ b/worlds/mario_kart_double_dash/__init__.py
@@ -4,7 +4,7 @@ Archipelago init file for Mario Kart Double Dash!!
 import math
 from typing import Any
 
-from BaseClasses import Region, ItemClassification
+from BaseClasses import Region, ItemClassification, Tutorial
 from worlds.AutoWorld import WebWorld, World
 from worlds.LauncherComponents import Component, components, launch_subprocess
 
@@ -18,6 +18,16 @@ from . import game_data, version
 
 class MkddWebWorld(WebWorld):
     theme = "ocean"
+    tutorials = [
+        Tutorial(
+            tutorial_name="Setup Guide",
+            description="A guide to setting up Mario Kart Double Dash for MultiworldGG.",
+            language="English",
+            file_name="setup_en.md",
+            link="setup/en",
+            authors=["aXu"],
+        )
+    ]
 
 
 class MkddWorld(World):
@@ -279,7 +289,7 @@ def add_client_to_launcher() -> None:
                 c.func = launch_client
                 return
     if not found:
-        components.append(Component("Mario Kart Double Dash Client", "MKDDClient", func=launch_client))
+        components.append(Component("Mario Kart Double Dash Client", func=launch_client))
 
 
 add_client_to_launcher()

--- a/worlds/mario_kart_double_dash/mkdd_client.py
+++ b/worlds/mario_kart_double_dash/mkdd_client.py
@@ -238,34 +238,12 @@ class MkddContext(CommonContext):
         :return: The client's GUI.
         """
         ui = super().make_gui()
-        ui.base_title = "Archipelago Mario Kart Double Dash Client"
-        return ui
-    
-    def run_gui(self):
-        from kvui import GameManager
-
-        class MkddManager(GameManager):
-            source = ""
-            logging_pairs = [("Client", "Archipelago")]
-            base_title = f"Mario Kart: Double Dash!! Client {version.get_str()}"
-            if tracker_loaded:
-                base_title += f" | Universal Tracker {UT_VERSION}"
-            base_title +=  " | Archipelago v"
-
-            def build(self):
-                container = super().build()
-                if tracker_loaded:
-                    self.ctx.build_gui(self)
-                else:
-                    logger.info("To enable a tracker, install Universal Tracker")
-
-                return container
-
-        self.ui = MkddManager(self)
+        ui.base_title = f"Mario Kart: Double Dash!! Client v{version.get_str()}"
         if tracker_loaded:
-            self.load_kv()
-        self.ui_task = asyncio.create_task(self.ui.async_run(), name="UI")
+            ui.base_title += f" | Universal Tracker {UT_VERSION}"
 
+        ui.base_title += " | Archipelago v"
+        return ui
 
 ###### Dolphin connection ######
 def _apply_ar_code(code: list[int]):


### PR DESCRIPTION
With 0.6.2 RC, AP added an icon_source element to the gamemanager that crashed the MKDD client.
This implementation following the Universal Tracker documentation allows for the same custom title text, but just inherits the GameManager, preventing this issue.

In addition, the second string argument in the Client component was removed, as it specifically is used to call a dedicated Client launcher py file in the AP root folder (deprecated behavior).

Finally, added the tutorial base class reference to make the setup guide show up on web.