### PR TITLE
Add Trophy Shuffle option

### DIFF
--- a/worlds/mario_kart_double_dash/docs/Mario Kart Double Dash.yaml
+++ b/worlds/mario_kart_double_dash/docs/Mario Kart Double Dash.yaml
@@ -44,6 +44,9 @@ Mario Kart Double Dash:
     # Minimum value is 0
     # Maximum value is 16
 
+  trophy_shuffle: false
+    # If enabled, gold trophies will be shuffled throughout the multiworld
+
   logic_difficulty: normal
     # Balances the difficulty modeling, how many upgrades you are presumed to have to win races.
     # Use normal (0) if you can comfortably win 100cc races.

--- a/worlds/mario_kart_double_dash/mkdd_client.py
+++ b/worlds/mario_kart_double_dash/mkdd_client.py
@@ -110,6 +110,7 @@ class MkddContext(CommonContext):
         self.trophy_goal: int
         self.all_cup_tour_length: int
         self.cups_courses: list[list[int]]
+        self.trophy_shuffle: bool
         self.mirror_200cc: bool
         self.lap_counts: dict[str, int]
 
@@ -196,6 +197,7 @@ class MkddContext(CommonContext):
             self.trophy_goal = slot_data.get("trophy_amount")
             self.cups_courses = slot_data["cups_courses"]
             self.all_cup_tour_length = slot_data.get("all_cup_tour_length", 8)
+            self.trophy_shuffle = bool(slot_data.get("trophy_shuffle"))
             self.mirror_200cc = bool(slot_data.get("mirror_200cc"))
             self.lap_counts = slot_data.get("lap_counts")
 

--- a/worlds/mario_kart_double_dash/options.py
+++ b/worlds/mario_kart_double_dash/options.py
@@ -17,6 +17,10 @@ class TrophyAmount(Range):
     range_end = 16
     default = 10
 
+class TrophyShuffle(Toggle):
+    """If enabled, gold trophies will be shuffled throughout the multiworld"""
+    display_name = "Trophy Shuffle"
+
 class LogicDifficulty(NamedRange):
     """Balances the difficulty modeling, how many upgrades you are presumed to have to win races.
     Use normal (0) if you can comfortably win 100cc races.
@@ -104,6 +108,8 @@ class KartUpgrades(Range):
 class MkddOptions(PerGameCommonOptions):
     goal: Goal
     trophy_amount: TrophyAmount
+    trophy_shuffle: TrophyShuffle
+
     logic_difficulty: LogicDifficulty
     tracker_unrestricted_logic: TrackerUnrestrictedLogic
     time_trials: TimeTrials


### PR DESCRIPTION
Add option to shuffle the gold trophies into the Archipelago multiworld.

Resolves issue #30 