### PR TITLE
Option to prevent item boxes from giving nothing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -306,7 +306,7 @@ class MkddWorld(World):
             "lap_counts": lap_counts,
             "character_item_total_weights": self.character_item_total_weights,
             "global_items_total_weights": self.global_items_total_weights,
-            "allow_nothings_in_item_boxes": int(self.allow_nothings_in_item_boxes.value),
+            "allow_nothings_in_item_boxes": int(self.options.allow_nothings_in_item_boxes.value),
         }
     
     # Rerun Universal Tracker with received options.

--- a/__init__.py
+++ b/__init__.py
@@ -306,6 +306,7 @@ class MkddWorld(World):
             "lap_counts": lap_counts,
             "character_item_total_weights": self.character_item_total_weights,
             "global_items_total_weights": self.global_items_total_weights,
+            "allow_nothings_in_item_boxes": int(self.allow_nothings_in_item_boxes.value),
         }
     
     # Rerun Universal Tracker with received options.

--- a/options.py
+++ b/options.py
@@ -127,6 +127,10 @@ class SpeedUpgrades(DefaultOnToggle):
     Disabling this sets logic difficulty on hard if it's lower."""
     display_name = "Speed Upgrades"
 
+class AllowNothingsInItemBoxes(Toggle):
+    """Are Nothings allowed in item boxes?"""
+    display_name = "Allow Nothings in item boxes"
+
 @dataclass
 class MkddOptions(PerGameCommonOptions):
     goal: Goal
@@ -152,3 +156,4 @@ class MkddOptions(PerGameCommonOptions):
     speed_upgrades: SpeedUpgrades
 
     start_inventory_from_pool: StartInventoryPool
+    allow_nothings_in_item_boxes: AllowNothingsInItemBoxes

--- a/options.py
+++ b/options.py
@@ -127,7 +127,7 @@ class SpeedUpgrades(DefaultOnToggle):
     Disabling this sets logic difficulty on hard if it's lower."""
     display_name = "Speed Upgrades"
 
-class AllowNothingsInItemBoxes(Toggle):
+class AllowNothingsInItemBoxes(DefaultOnToggle):
     """Are Nothings allowed in item boxes?"""
     display_name = "Allow Nothings in item boxes"
 


### PR DESCRIPTION
Adds `allow_nothings_in_item_boxes` to yaml settings. It basically removes `ITEM_NONE` from the item pool, making the player never getting `ITEM_NONE` unless there's no item unlocked at all.