### PR TITLE
Raise caps for items and kart upgrades

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,6 +59,8 @@ class MkddWorld(World):
         self.cups_courses: list[list[int]] = []
         self.character_item_total_weights: dict[str, list[int]] = {}
         self.global_items_total_weights: list[int] = []
+
+        self.logger: logging.Logger = logging.getLogger("MKDD Logger")
         super(MkddWorld, self).__init__(world, player)
 
     def generate_early(self):
@@ -67,7 +69,7 @@ class MkddWorld(World):
         if self.options.grand_prix_trophies:
             max_requirement += 16
         if self.options.trophy_requirement.value > max_requirement:
-            logging.getLogger("MKDD Logger").warning(f"{self.player_name}: Requirement for trophies is higher than available trophies. Adding extra trophies...")
+            self.logger.warning(f"{self.player_name}: Requirement for trophies is higher than available trophies. Adding extra trophies...")
             self.options.shuffle_extra_trophies.value = self.options.trophy_requirement.value
             if self.options.grand_prix_trophies:
                 self.options.shuffle_extra_trophies.value -= 16
@@ -189,7 +191,7 @@ class MkddWorld(World):
             # Set minimum difficulty on "hard", otherwise the seed can be unbeatable.
             if self.options.logic_difficulty.value < game_data.ENGINE_UPGRADE_USEFULNESS:
                 self.options.logic_difficulty.value = game_data.ENGINE_UPGRADE_USEFULNESS
-                logging.getLogger("MKDD Logger").warning(f"{self.player_name}: No engine upgrades are available, setting difficulty to hard.")
+                self.logger.warning(f"{self.player_name}: No engine upgrades are available, setting difficulty to hard.")
         for item in precollected:
             self.multiworld.push_precollected(self.create_item(item))
 
@@ -268,11 +270,6 @@ class MkddWorld(World):
                     # Refill the pool with some balancing.
                     items_left = items_left_characters_pool.copy()
                     weights = [10 - item.usefulness for item in items_left]
-                # There can be too much of these, so generate only as long as there's enough locations.
-                if len(item_pool) == total_locations:
-                    break
-            if len(item_pool) == total_locations:
-                break
         # In case the user has specified no items, force at least one boost item for all locations be reachable.
         if self.options.items_for_everybody + self.options.items_per_character + self.options.start_items_per_character == 0:
             item_pool.append(self.create_item(items.get_item_name_character_item(game_data.CHARACTERS[0].name, game_data.ITEM_MUSHROOM.name)))
@@ -284,6 +281,15 @@ class MkddWorld(World):
                 self.character_item_total_weights[character.name].append(
                     sum([item.weight_table[i] for item in items_per_character[character]])
                 )
+
+        # Remove some items if there are more items than locations.
+        if len(item_pool) > total_locations:
+            self.logger.warning(f"{self.player_name}: Too many items, removing {len(item_pool) - total_locations} items from the pool.")
+        while len(item_pool) > total_locations:
+            item: items.MkddItem = self.random.choice(item_pool)
+            item_type: items.ItemType = items.data_table[item.code].item_type
+            if item_type == items.ItemType.KART_UPGRADE or item_type == items.ItemType.ITEM_UNLOCK:
+                item_pool.remove(item)
 
         remaining_item_count = total_locations - len(item_pool)
         trap_count = int(remaining_item_count * self.options.trap_chance / 100)

--- a/docs/mario_kart_double_dash_template.yaml
+++ b/docs/mario_kart_double_dash_template.yaml
@@ -101,20 +101,19 @@ Mario Kart Double Dash:
 
   items_per_character: 3
     # How many item unlocks there are per character.
-    # Note: this setting raises the amount of items in item pool considerably, and might cause the generation to fail.
     # Minimum value is 0
-    # Maximum value is 4
+    # Maximum value is 5
 
   start_items_per_character: 1
     # Unlocks some items for the characters straight away.
     # Minimum value is 0
     # Maximum value is 5
 
-  kart_upgrades: 10
+  kart_upgrades: 20
     # How many random kart stat upgrades there are total.
     # Unlike progressive engine upgrades, these upgrades are tied to certain vehicles.
     # Minimum value is 0
-    # Maximum value is 40
+    # Maximum value is 100
 
   speed_upgrades: true
     # Adds 3 Progressive Speed Upgrades to the pool.
@@ -125,6 +124,11 @@ Mario Kart Double Dash:
   item_boxes_as_locations: interesting_locations
     # Makes some item boxes count as checks.
     # Possible values: disabled, interesting_locations
+
+  trap_chance: 5
+    # Percentage of how many filler items are converted into traps.
+    # Minimum value is 0
+    # Maximum value is 100
 
   # Item & Location Options
   local_items: []

--- a/options.py
+++ b/options.py
@@ -97,11 +97,10 @@ class ItemsForEverybody(Range):
     default = 4
 
 class ItemsPerCharacter(Range):
-    """How many item unlocks there are per character.
-    Note: this setting raises the amount of items in item pool considerably, and might cause the generation to fail."""
+    """How many item unlocks there are per character."""
     display_name = "Items per Character"
     range_start = 0
-    range_end = 4
+    range_end = 5
     default = 3
 
 class StartItemsPerCharacter(Range):
@@ -116,8 +115,8 @@ class KartUpgrades(Range):
     Unlike progressive engine upgrades, these upgrades are tied to certain vehicles."""
     display_name = "Kart Upgrades"
     range_start = 0
-    range_end = 40
-    default = 10
+    range_end = 100
+    default = 20
 
 class SpeedUpgrades(DefaultOnToggle):
     """Adds 3 Progressive Speed Upgrades to the pool.


### PR DESCRIPTION
New caps: 100 kart upgrades, 5 items per character. Increase default kart upgrades to 20.
Remove random items from pool if there's too much.