### PR TITLE
Add frantic and guaranteed items

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -276,10 +276,10 @@ class MkddWorld(World):
 
         self.character_item_total_weights = {character.name:[] for character in game_data.CHARACTERS}
         for i in range(8):
-            self.global_items_total_weights.append(sum([item.weight_table[i] for item in global_items]))
+            self.global_items_total_weights.append(sum([item.get_weight(i, self.options.frantic_items) for item in global_items]))
             for character in game_data.CHARACTERS:
                 self.character_item_total_weights[character.name].append(
-                    sum([item.weight_table[i] for item in items_per_character[character]])
+                    sum([item.get_weight(i, self.options.frantic_items) for item in items_per_character[character]])
                 )
 
         # Remove some items if there are more items than locations.

--- a/docs/mario_kart_double_dash_template.yaml
+++ b/docs/mario_kart_double_dash_template.yaml
@@ -113,6 +113,12 @@ Mario Kart Double Dash:
     # Minimum value is 0
     # Maximum value is 5
 
+  frantic_items: vanilla
+    # Changes the item distribution to give all items evenly regardless of current position.
+    # Minimum value is 0
+    # Maximum value is 100
+    # Possible values: vanilla (=0), medium (=50), frantic (=100)
+
   kart_upgrades: 20
     # How many random kart stat upgrades there are total.
     # Unlike progressive engine upgrades, these upgrades are tied to certain vehicles.

--- a/docs/mario_kart_double_dash_template.yaml
+++ b/docs/mario_kart_double_dash_template.yaml
@@ -119,6 +119,11 @@ Mario Kart Double Dash:
     # Maximum value is 100
     # Possible values: vanilla (=0), medium (=50), frantic (=100)
 
+  guaranteed_items: true
+    # Guarantees getting unlocked items if they are appropriate for your position.
+    # For example, if your character has mushroom unlocked, you cannot get blank item at 4th or worse place.
+    # Possible values: true, false
+
   kart_upgrades: 20
     # How many random kart stat upgrades there are total.
     # Unlike progressive engine upgrades, these upgrades are tied to certain vehicles.

--- a/game_data.py
+++ b/game_data.py
@@ -172,26 +172,29 @@ class Item(NamedTuple):
     weight_table: list[int] = []
     is_boost_item: bool = False
 
+    def get_weight(self, rank: int, frantic: int) -> int:
+        return int((self.weight_table[rank] * (100 - frantic) + 100 * frantic) / 100)
+
 ITEMS = [
-    Item(0, "Green Shell", "GrSh",          2, [ 90,  50,  25,  10,   1,   1,   1,   1]),
-    Item(1, "Bowser's Shell", "BoSh",       3, [ 30,  60, 100, 100, 100,  90,  40,   1]),
+    Item(0, "Green Shell", "GrSh",          2, [ 90,  50,  25,  10,   0,   0,   0,   0]),
+    Item(1, "Bowser's Shell", "BoSh",       3, [ 30,  60, 100, 100, 100,  90,  40,   0]),
     Item(2, "Red Shell", "ReSh",            3, [ 10,  55,  70,  70,  70,  50,  40,  20]),
-    Item(3, "Banana", "Ba",                 1, [ 70,  35,  15,   5,   1,   1,   1,   1]),
-    Item(4, "Giant Banana", "GBa",          2, [120, 100,  90,  60,  30,   1,   1,   1]),
-    Item(5, "Mushroom", "Mu",               4, [  1,  40,  65,  75,  65,  35,  10,  10], is_boost_item=True),
-    Item(6, "Star", "St",                   5, [  1,   1,   1,  10,  20,  30,  40,  40], is_boost_item=True),
-    Item(7, "Chain Chomp", "CC",            4, [  0,   0,   1,   3,  20,  60, 130, 180], is_boost_item=True),
+    Item(3, "Banana", "Ba",                 1, [ 70,  35,  15,   5,   0,   0,   0,   0]),
+    Item(4, "Giant Banana", "GBa",          2, [120, 100,  90,  60,  30,   0,   0,   0]),
+    Item(5, "Mushroom", "Mu",               4, [  0,  40,  65,  75,  65,  35,  10,  10], is_boost_item=True),
+    Item(6, "Star", "St",                   5, [  0,   0,   0,  10,  20,  30,  40,  40], is_boost_item=True),
+    Item(7, "Chain Chomp", "CC",            4, [  0,   0,   0,   3,  20,  60, 130, 180], is_boost_item=True),
     Item(8, "Bob-omb", "Bo",                1, [ 10,  70, 100, 100, 100,  90,  40,   0]),
-    Item(10, "Lightning", "Li",             3, [  0,   0,   1,   1,   3,  10,  20,  30]),
+    Item(10, "Lightning", "Li",             3, [  0,   0,   0,   0,   3,  10,  20,  30]),
     Item(11, "Yoshi Egg", "Eg",             4, [ 50,  70,  80,  80,  80,  70,  60,  40]),
     Item(12, "Golden Mushroom", "GMu",      6, [  0,   3,  10,  30,  50,  80, 100, 120], is_boost_item=True),
     Item(13, "Spiny Shell", "SpSh",         0, [  0,   0,   5,  10,  10,  20,  20,  20]),
-    Item(14, "Heart", "He",                 4, [  1,   1,   3,  10,  30,  90, 110, 130]),
-    Item(15, "Fake Item", "FI",             0, [ 30,  20,  10,   0,   0,   0,   0,   1]),
-    Item(17, "Triple Green Shells", "3GS",  3, [ 20,  50, 100, 100, 100,  90,  40,   1]),
-    Item(18, "Triple Mushrooms", "3Mu",     6, [  1,   1,  10,  20,  35,  50,  70,  90], is_boost_item=True),
+    Item(14, "Heart", "He",                 4, [  0,   0,   3,  10,  30,  90, 110, 130]),
+    Item(15, "Fake Item", "FI",             0, [ 30,  20,  10,   0,   0,   0,   0,   0]),
+    Item(17, "Triple Green Shells", "3GS",  3, [ 20,  50, 100, 100, 100,  90,  40,   0]),
+    Item(18, "Triple Mushrooms", "3Mu",     6, [  0,   0,  10,  20,  35,  50,  70,  90], is_boost_item=True),
     Item(19, "Triple Red Shells", "3RS",    4, [  5,  40,  60,  70,  70,  50,  50,  30]),
-    Item(21, "Fireballs", "Fi",             2, [ 30,  70, 100, 100, 100,  90,  40,   1]),
+    Item(21, "Fireballs", "Fi",             2, [ 30,  70, 100, 100, 100,  90,  40,   0]),
     Item(20, "None", "",                    0, [  0,   0,   0,   0,   0,   0,   0,   0]),
 ]
 

--- a/game_data.py
+++ b/game_data.py
@@ -170,32 +170,41 @@ class Item(NamedTuple):
     short_name: str
     usefulness: int = 0
     weight_table: list[int] = []
+    guaranteed_position: int = 0
     is_boost_item: bool = False
+    no_first_place: bool = False
 
     def get_weight(self, rank: int, frantic: int) -> int:
+        if self.no_first_place and rank == 0:
+            return 0
         return int((self.weight_table[rank] * (100 - frantic) + 100 * frantic) / 100)
 
+    def is_guaranteened(self, rank: int, frantic: int) -> bool:
+        if self.no_first_place and rank == 0:
+            return False
+        return rank >= round(self.guaranteed_position * (1 - frantic / 100))
+
 ITEMS = [
-    Item(0, "Green Shell", "GrSh",          2, [ 90,  50,  25,  10,   0,   0,   0,   0]),
-    Item(1, "Bowser's Shell", "BoSh",       3, [ 30,  60, 100, 100, 100,  90,  40,   0]),
-    Item(2, "Red Shell", "ReSh",            3, [ 10,  55,  70,  70,  70,  50,  40,  20]),
-    Item(3, "Banana", "Ba",                 1, [ 70,  35,  15,   5,   0,   0,   0,   0]),
-    Item(4, "Giant Banana", "GBa",          2, [120, 100,  90,  60,  30,   0,   0,   0]),
-    Item(5, "Mushroom", "Mu",               4, [  0,  40,  65,  75,  65,  35,  10,  10], is_boost_item=True),
-    Item(6, "Star", "St",                   5, [  0,   0,   0,  10,  20,  30,  40,  40], is_boost_item=True),
-    Item(7, "Chain Chomp", "CC",            4, [  0,   0,   0,   3,  20,  60, 130, 180], is_boost_item=True),
-    Item(8, "Bob-omb", "Bo",                1, [ 10,  70, 100, 100, 100,  90,  40,   0]),
-    Item(10, "Lightning", "Li",             3, [  0,   0,   0,   0,   3,  10,  20,  30]),
-    Item(11, "Yoshi Egg", "Eg",             4, [ 50,  70,  80,  80,  80,  70,  60,  40]),
-    Item(12, "Golden Mushroom", "GMu",      6, [  0,   3,  10,  30,  50,  80, 100, 120], is_boost_item=True),
-    Item(13, "Spiny Shell", "SpSh",         0, [  0,   0,   5,  10,  10,  20,  20,  20]),
-    Item(14, "Heart", "He",                 4, [  0,   0,   3,  10,  30,  90, 110, 130]),
-    Item(15, "Fake Item", "FI",             0, [ 30,  20,  10,   0,   0,   0,   0,   0]),
-    Item(17, "Triple Green Shells", "3GS",  3, [ 20,  50, 100, 100, 100,  90,  40,   0]),
-    Item(18, "Triple Mushrooms", "3Mu",     6, [  0,   0,  10,  20,  35,  50,  70,  90], is_boost_item=True),
-    Item(19, "Triple Red Shells", "3RS",    4, [  5,  40,  60,  70,  70,  50,  50,  30]),
-    Item(21, "Fireballs", "Fi",             2, [ 30,  70, 100, 100, 100,  90,  40,   0]),
-    Item(20, "None", "",                    0, [  0,   0,   0,   0,   0,   0,   0,   0]),
+    Item(0, "Green Shell", "GrSh",          2, [ 90,  50,  25,  10,   0,   0,   0,   0], 0),
+    Item(1, "Bowser's Shell", "BoSh",       3, [ 30,  60, 100, 100, 100,  90,  40,   0], 2),
+    Item(2, "Red Shell", "ReSh",            3, [ 10,  55,  70,  70,  70,  50,  40,  20], 2),
+    Item(3, "Banana", "Ba",                 1, [ 70,  35,  15,   5,   0,   0,   0,   0], 0),
+    Item(4, "Giant Banana", "GBa",          2, [120, 100,  90,  60,  30,   0,   0,   0], 0),
+    Item(5, "Mushroom", "Mu",               4, [  0,  40,  65,  75,  65,  35,  10,  10], 3, is_boost_item=True),
+    Item(6, "Star", "St",                   5, [  0,   0,   0,  10,  20,  30,  40,  40], 6, is_boost_item=True),
+    Item(7, "Chain Chomp", "CC",            4, [  0,   0,   0,   3,  20,  60, 130, 180], 6, is_boost_item=True),
+    Item(8, "Bob-omb", "Bo",                1, [ 10,  70, 100, 100, 100,  90,  40,   0], 1),
+    Item(10, "Lightning", "Li",             3, [  0,   0,   0,   0,   3,  10,  20,  30], 7),
+    Item(11, "Yoshi Egg", "Eg",             4, [ 50,  70,  80,  80,  80,  70,  60,  40], 1),
+    Item(12, "Golden Mushroom", "GMu",      6, [  0,   3,  10,  30,  50,  80, 100, 120], 5, is_boost_item=True),
+    Item(13, "Spiny Shell", "SpSh",         0, [  0,   0,   5,  10,  10,  20,  20,  20], 6, no_first_place=True),
+    Item(14, "Heart", "He",                 4, [  0,   0,   3,  10,  30,  90, 110, 130], 5),
+    Item(15, "Fake Item", "FI",             0, [ 30,  20,  10,   0,   0,   0,   0,   0], 0),
+    Item(17, "Triple Green Shells", "3GS",  3, [ 20,  50, 100, 100, 100,  90,  40,   0], 2),
+    Item(18, "Triple Mushrooms", "3Mu",     6, [  0,   0,  10,  20,  35,  50,  70,  90], 5, is_boost_item=True),
+    Item(19, "Triple Red Shells", "3RS",    4, [  5,  40,  60,  70,  70,  50,  50,  30], 3),
+    Item(21, "Fireballs", "Fi",             2, [ 30,  70, 100, 100, 100,  90,  40,   0], 1),
+    Item(20, "None", "",                    0, [  0,   0,   0,   0,   0,   0,   0,   0], 8),
 ]
 
 ITEM_GREEN_SHELL = ITEMS[0]

--- a/game_state.py
+++ b/game_state.py
@@ -542,7 +542,7 @@ class MkddGameState():
             return
         
         def _calculate_and_apply(adr: int, pool: list[game_data.Item], total_weight: int) -> None:
-            item_weights = [item.weight_table[self.in_race_placement] for item in pool]
+            item_weights = [item.get_weight(self.in_race_placement, self.options.frantic_items) for item in pool]
             # Yet to be unlocked items still count towards item weights so fill the rest with nothing.
             weight_gap = total_weight - sum(item_weights)
             if weight_gap > 0:

--- a/game_state.py
+++ b/game_state.py
@@ -544,13 +544,19 @@ class MkddGameState():
         def _calculate_and_apply(adr: int, pool: list[game_data.Item], total_weight: int) -> None:
             item_weights = [item.get_weight(self.in_race_placement, self.options.frantic_items) for item in pool]
             # Yet to be unlocked items still count towards item weights so fill the rest with nothing.
+            normal_pool: list[game_data.Item] = pool.copy()
             weight_gap = total_weight - sum(item_weights)
             if weight_gap > 0:
-                pool.append(game_data.ITEM_NONE)
+                normal_pool.append(game_data.ITEM_NONE)
                 item_weights.append(weight_gap)
             rand_item = game_data.ITEM_NONE
-            if len(pool) > 0:
-                rand_item = random.sample(pool, 1, counts = item_weights)[0]
+            if len(normal_pool) > 0:
+                rand_item = random.sample(normal_pool, 1, counts = item_weights)[0]
+            if rand_item == game_data.ITEM_NONE and self.options.guaranteed_items:
+                guaranteed_pool: list[game_data.Item] = [i for i in pool if i.is_guaranteened(self.in_race_placement, self.options.frantic_items)]
+                item_weights = [max(30, item.get_weight(self.in_race_placement, self.options.frantic_items)) for item in guaranteed_pool]
+                if len(guaranteed_pool) > 0:
+                    rand_item = random.sample(guaranteed_pool, 1, counts = item_weights)[0]
             dolphin.write_byte(adr, rand_item.id)
         
         item_adr_0: int = self.memory_addresses.gp_next_items_bx + self.active_characters[0].item_offset

--- a/options.py
+++ b/options.py
@@ -126,6 +126,11 @@ class FranticItems(Range):
         "frantic": 100,
     }
 
+class GuaranteedItems(DefaultOnToggle):
+    """Guarantees getting unlocked items if they are appropriate for your position.
+    For example, if your character has mushroom unlocked, you cannot get blank item at 4th or worse place."""
+    display_name = "Guaranteed Items"
+
 class KartUpgrades(Range):
     """How many random kart stat upgrades there are total.
     Unlike progressive engine upgrades, these upgrades are tied to certain vehicles."""
@@ -185,6 +190,7 @@ class MkddOptions(PerGameCommonOptions):
     items_per_character: ItemsPerCharacter
     start_items_per_character: StartItemsPerCharacter
     frantic_items: FranticItems
+    guaranteed_items: GuaranteedItems
 
     kart_upgrades: KartUpgrades
     speed_upgrades: SpeedUpgrades
@@ -207,6 +213,7 @@ class MkddOptions(PerGameCommonOptions):
             "mirror_200cc",
             "faster_50cc_100cc",
             "frantic_items",
+            "guaranteed_items",
             "item_boxes_as_locations",
             "add_custom_item_boxes",
         )

--- a/options.py
+++ b/options.py
@@ -114,6 +114,18 @@ class StartItemsPerCharacter(Range):
     range_end = 5
     default = 1
 
+class FranticItems(Range):
+    """Changes the item distribution to give all items evenly regardless of current position."""
+    display_name = "Frantic Items"
+    range_start = 0
+    range_end = 100
+    default = 0
+    special_range_names = {
+        "vanilla": 0,
+        "medium": 50,
+        "frantic": 100,
+    }
+
 class KartUpgrades(Range):
     """How many random kart stat upgrades there are total.
     Unlike progressive engine upgrades, these upgrades are tied to certain vehicles."""
@@ -172,6 +184,7 @@ class MkddOptions(PerGameCommonOptions):
     items_for_everybody: ItemsForEverybody
     items_per_character: ItemsPerCharacter
     start_items_per_character: StartItemsPerCharacter
+    frantic_items: FranticItems
 
     kart_upgrades: KartUpgrades
     speed_upgrades: SpeedUpgrades
@@ -193,6 +206,7 @@ class MkddOptions(PerGameCommonOptions):
             "custom_lap_counts",
             "mirror_200cc",
             "faster_50cc_100cc",
+            "frantic_items",
             "item_boxes_as_locations",
             "add_custom_item_boxes",
         )


### PR DESCRIPTION
Add frantic items option, which makes the item probabilities flatter (from 0 to 100, vanilla to all items equal). Spiny shells can't be get in first place.
Add guaranteed items option, which ensures that you will get some items as long you have unlocked an item appropriate for your placement (you won't be guaranteed to get a mushroom on first place, for example).