### PR TITLE
Give star for shortcuts if no items enabled

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -276,8 +276,11 @@ class MkddWorld(World):
                     items_left = items_left_characters_pool.copy()
                     weights = [10 - item.usefulness for item in items_left]
         # In case the user has specified no items, force at least one boost item for all locations be reachable.
-        if self.options.items_for_everybody + self.options.items_per_character + self.options.start_items_per_character == 0:
-            item_pool.append(self.create_item(items.get_item_name_character_item(game_data.CHARACTERS[0].name, game_data.ITEM_MUSHROOM.name)))
+        if (self.options.shortcuts_as_locations
+            and self.options.time_trials == self.options.time_trials.option_disable
+            and self.options.items_for_everybody + self.options.items_per_character + self.options.start_items_per_character == 0):
+            item_pool.append(self.create_item(items.get_item_name_character_item(game_data.CHARACTERS[0].name, game_data.ITEM_STAR.name)))
+        
 
         self.character_item_total_weights = {character.name:[] for character in game_data.CHARACTERS}
         for i in range(8):


### PR DESCRIPTION
Ensure accessibility for shortcut locations even if the user has disabled all items.