### PR TITLE
Fix time trial ghosts desyncing

### DIFF
--- a/asm/patch.asm
+++ b/asm/patch.asm
@@ -267,16 +267,25 @@ WriteTo code_vehicle_class_left
 
 
 REGION time_trial_items
+# Ghost karts (kart number != 0) keep the vanilla single mushroom they were
+# recorded with, otherwise they desync (issue #41).
 # Driver
 .set code_tt_items_driver, 0x802baf7c
-InsertAt code_tt_items_driver, 2
+InsertAt code_tt_items_driver, 6
+    li      r4, 5               # Default code (vanilla single mushroom).
+    lbz     r6, 0x5b3 (r31)     # Kart number.
+    cmplwi  r6, 0
+    bne-    0xc                 # Ghosts get the vanilla item.
     lis     r4, tt_items_driver_b@ha
     lbz     r4, tt_items_driver_b@l (r4)
 Return
 
 # Rider
 .set code_tt_items_rider, 0x802bafa8
-InsertAt code_tt_items_rider, 2
+InsertAt code_tt_items_rider, 5
+    li      r4, 5               # Default code (vanilla single mushroom).
+    cmplwi  r5, 0               # r5 = kart number.
+    bne-    0xc                 # Ghosts get the vanilla item.
     lis     r4, tt_items_rider_b@ha
     lbz     r4, tt_items_rider_b@l (r4)
 Return

--- a/game_state.py
+++ b/game_state.py
@@ -937,6 +937,11 @@ class MkddGameState():
         # Make sure the kart instance is initialized and drives the kart we think it does.
         if dolphin.read_word(kart_address + self.memory_addresses.kart_body_kart_id_w_offset) != self.active_kart.id:
             return
+        # During race init the pointer slot can briefly hold another kart's body.
+        # If it drives the same kart model the id check won't catch it, which gave
+        # the player's upgrades to same-kart time trial ghosts (issue #41 again).
+        if dolphin.read_byte(kart_address + self.memory_addresses.kart_body_mynum_b_offset) != 0:
+            return
 
         stats = self.get_modified_kart_stats(self.active_kart.id, True)
         # The instance speeds include the vehicle class multiplier.

--- a/game_state.py
+++ b/game_state.py
@@ -928,12 +928,12 @@ class MkddGameState():
         fields are copied from the stat table at race init, so they can be
         overwritten at any point after that.
         """
+        # Outside a race the kart pointers hold stale or garbage values, reading
+        # through them gives invalid addresses.
+        if not self.in_game:
+            return
         kart_ctrl: int = dolphin.read_word(self.memory_addresses.kart_control_pointer)
-        if kart_ctrl == 0:
-            return
         kart_address: int = dolphin.read_word(kart_ctrl + self.memory_addresses.kart_control_kart_pointers_offset)
-        if kart_address == 0:
-            return
         # Make sure the kart instance is initialized and drives the kart we think it does.
         if dolphin.read_word(kart_address + self.memory_addresses.kart_body_kart_id_w_offset) != self.active_kart.id:
             return

--- a/game_state.py
+++ b/game_state.py
@@ -848,55 +848,109 @@ class MkddGameState():
                 return 1.0
 
 
+    def get_modified_kart_stats(self, kart_id: int, apply_upgrades: bool) -> game_data.KartStats:
+        """Returns kart stats, with speed modifiers and unlocked upgrades applied if requested."""
+        stats = game_data.KARTS[kart_id].stats
+        if not apply_upgrades:
+            return stats
+
+        speed_1_multiplier = self.calculate_speed_multiplier()
+        speed_2_multiplier = 1.0
+        speed_3_multiplier = 1.0
+        speed_4_multiplier = 1.0
+        acceleration_1_addition = 0.0
+        acceleration_2_addition = 0.0
+        mini_turbo_addition = 0.0
+        weight_addition = 0.0
+        steer_addition = 0.0
+        for upgrade in self.kart_upgrades[kart_id]:
+            if upgrade == game_data.KART_UPGRADE_ACC:
+                acceleration_1_addition += 1
+                acceleration_2_addition += .1
+            elif upgrade == game_data.KART_UPGRADE_OFFROAD:
+                speed_2_multiplier *= 1.1
+                speed_3_multiplier *= 1.2
+                speed_4_multiplier *= 3
+            elif upgrade == game_data.KART_UPGRADE_WEIGHT:
+                weight_addition += 2
+            elif upgrade == game_data.KART_UPGRADE_TURBO:
+                mini_turbo_addition += 30
+            elif upgrade == game_data.KART_UPGRADE_STEER:
+                steer_addition += 1
+        # Speed 1 (on road) is also general speed multiplier.
+        return game_data.KartStats(
+            speed_on_road = stats.speed_on_road * speed_1_multiplier,
+            speed_off_road_sand = stats.speed_off_road_sand * speed_2_multiplier * speed_1_multiplier,
+            speed_off_road_grass = stats.speed_off_road_grass * speed_3_multiplier * speed_1_multiplier,
+            speed_off_road_mud = stats.speed_off_road_mud * speed_4_multiplier * speed_1_multiplier,
+            acceleration_1 = stats.acceleration_1 + acceleration_1_addition,
+            acceleration_2 = stats.acceleration_2 + acceleration_2_addition,
+            mini_turbo = stats.mini_turbo + mini_turbo_addition,
+            mass = stats.mass + weight_addition,
+            roll = stats.roll,
+            steer = stats.steer + steer_addition,
+        )
+
+
     def apply_kart_stats(self) -> None:
         """Writes custom kart stats into game."""
+        # In time trials the shared stat table is kept vanilla, so that ghost karts
+        # initialize with the stats they were recorded with (issue #41). The player's
+        # upgrades are applied directly to the kart instance instead.
+        time_trial: bool = self.mode == game_data.Modes.TIMETRIAL
         kart_stats_pointer = self.memory_addresses.kart_stats_pointer
         for i in range(len(game_data.KARTS)):
-            kart: game_data.Kart = game_data.KARTS[i]
             kart_address = kart_stats_pointer + i * self.memory_addresses.kart_struct_size
-
-            speed_1_multiplier = 1.0
-            speed_2_multiplier = 1.0
-            speed_3_multiplier = 1.0
-            speed_4_multiplier = 1.0
-            acceleration_1_addition = 0.0
-            acceleration_2_addition = 0.0
-            mini_turbo_addition = 0.0
-            weight_addition = 0.0
-            steer_addition = 0.0
             # Upgrades apply to the player only (by side-effect also bots using the same kart).
-            if kart == self.active_kart:
-                speed_1_multiplier = self.calculate_speed_multiplier()
-                for upgrade in self.kart_upgrades[i]:
-                    if upgrade == game_data.KART_UPGRADE_ACC:
-                        acceleration_1_addition += 1
-                        acceleration_2_addition += .1
-                    elif upgrade == game_data.KART_UPGRADE_OFFROAD:
-                        speed_2_multiplier *= 1.1
-                        speed_3_multiplier *= 1.2
-                        speed_4_multiplier *= 3
-                    elif upgrade == game_data.KART_UPGRADE_WEIGHT:
-                        weight_addition += 2
-                    elif upgrade == game_data.KART_UPGRADE_TURBO:
-                        mini_turbo_addition += 30
-                    elif upgrade == game_data.KART_UPGRADE_STEER:
-                        steer_addition += 1
-            # Speed 1 (on road) is also general speed multiplier.
-            speed_2_multiplier *= speed_1_multiplier
-            speed_3_multiplier *= speed_1_multiplier
-            speed_4_multiplier *= speed_1_multiplier
-            stats = kart.stats
-            
-            dolphin.write_float(kart_address + self.memory_addresses.kart_speed_on_road_f_offset, stats.speed_on_road * speed_1_multiplier)
-            dolphin.write_float(kart_address + self.memory_addresses.kart_speed_off_road_sand_f_offset, stats.speed_off_road_sand * speed_2_multiplier)
-            dolphin.write_float(kart_address + self.memory_addresses.kart_speed_off_road_grass_f_offset, stats.speed_off_road_grass * speed_3_multiplier)
-            dolphin.write_float(kart_address + self.memory_addresses.kart_speed_off_road_mud_f_offset, stats.speed_off_road_mud * speed_4_multiplier)
-            dolphin.write_float(kart_address + self.memory_addresses.kart_acceleration_1_f_offset, stats.acceleration_1 + acceleration_1_addition)
-            dolphin.write_float(kart_address + self.memory_addresses.kart_acceleration_2_f_offset, stats.acceleration_2 + acceleration_2_addition)
-            dolphin.write_float(kart_address + self.memory_addresses.kart_mini_turbo_f_offset, stats.mini_turbo + mini_turbo_addition)
-            dolphin.write_float(kart_address + self.memory_addresses.kart_mass_f_offset, stats.mass + weight_addition)
+            apply_upgrades: bool = game_data.KARTS[i] == self.active_kart and not time_trial
+            stats = self.get_modified_kart_stats(i, apply_upgrades)
+
+            dolphin.write_float(kart_address + self.memory_addresses.kart_speed_on_road_f_offset, stats.speed_on_road)
+            dolphin.write_float(kart_address + self.memory_addresses.kart_speed_off_road_sand_f_offset, stats.speed_off_road_sand)
+            dolphin.write_float(kart_address + self.memory_addresses.kart_speed_off_road_grass_f_offset, stats.speed_off_road_grass)
+            dolphin.write_float(kart_address + self.memory_addresses.kart_speed_off_road_mud_f_offset, stats.speed_off_road_mud)
+            dolphin.write_float(kart_address + self.memory_addresses.kart_acceleration_1_f_offset, stats.acceleration_1)
+            dolphin.write_float(kart_address + self.memory_addresses.kart_acceleration_2_f_offset, stats.acceleration_2)
+            dolphin.write_float(kart_address + self.memory_addresses.kart_mini_turbo_f_offset, stats.mini_turbo)
+            dolphin.write_float(kart_address + self.memory_addresses.kart_mass_f_offset, stats.mass)
             dolphin.write_float(kart_address + self.memory_addresses.kart_roll_f_offset, stats.roll)
-            dolphin.write_float(kart_address + self.memory_addresses.kart_steer_f_offset, stats.steer + steer_addition)
+            dolphin.write_float(kart_address + self.memory_addresses.kart_steer_f_offset, stats.steer)
+
+        if time_trial:
+            self.apply_player_kart_body_stats()
+
+
+    def apply_player_kart_body_stats(self) -> None:
+        """Applies upgraded stats directly to the player's kart instance.
+
+        Used in time trials, where the shared stat table must stay vanilla so that
+        ghost karts don't pick up the player's upgrades (issue #41). The instance
+        fields are copied from the stat table at race init, so they can be
+        overwritten at any point after that.
+        """
+        kart_ctrl: int = dolphin.read_word(self.memory_addresses.kart_control_pointer)
+        if kart_ctrl == 0:
+            return
+        kart_address: int = dolphin.read_word(kart_ctrl + self.memory_addresses.kart_control_kart_pointers_offset)
+        if kart_address == 0:
+            return
+        # Make sure the kart instance is initialized and drives the kart we think it does.
+        if dolphin.read_word(kart_address + self.memory_addresses.kart_body_kart_id_w_offset) != self.active_kart.id:
+            return
+
+        stats = self.get_modified_kart_stats(self.active_kart.id, True)
+        # The instance speeds include the vehicle class multiplier.
+        vehicle_class: int = min(2, dolphin.read_byte(kart_address + self.memory_addresses.kart_body_class_b_offset))
+        class_multiplier: float = dolphin.read_float(self.memory_addresses.class_speed_multipliers_fx + vehicle_class * 4)
+        speeds = [stats.speed_on_road, stats.speed_off_road_sand, stats.speed_off_road_grass, stats.speed_off_road_mud]
+        for idx, speed in enumerate(speeds):
+            dolphin.write_float(kart_address + self.memory_addresses.kart_body_speeds_fx_offset + idx * 4, speed * class_multiplier)
+        dolphin.write_float(kart_address + self.memory_addresses.kart_body_acceleration_1_f_offset, stats.acceleration_1)
+        dolphin.write_float(kart_address + self.memory_addresses.kart_body_acceleration_2_f_offset, stats.acceleration_2)
+        # Mini-turbo boost duration is a halfword, 1 + stat table value.
+        dolphin.write_bytes(kart_address + self.memory_addresses.kart_body_mini_turbo_max_h_offset, int(1 + stats.mini_turbo).to_bytes(2, "big"))
+        dolphin.write_float(kart_address + self.memory_addresses.kart_body_mass_f_offset, stats.mass)
+        dolphin.write_float(kart_address + self.memory_addresses.kart_body_steer_f_offset, stats.steer)
 
 
     def calculate_speed_multiplier(self) -> float:

--- a/game_state.py
+++ b/game_state.py
@@ -920,6 +920,21 @@ class MkddGameState():
             self.apply_player_kart_body_stats()
 
 
+    def get_kart_body_kart_id(self, kart_address: int) -> int:
+        """Returns the kart id (stat table row) a kart body drives, or -1 if the
+        body isn't initialized. Derived from the body's stat table pointer; the
+        id-looking word at +0x5a8 is a different index space and reads garbage
+        for grand prix rosters."""
+        setting_ptr: int = dolphin.read_word(kart_address + self.memory_addresses.kart_body_setting_ptr_offset)
+        offset: int = setting_ptr - self.memory_addresses.kart_stats_pointer
+        if offset < 0 or offset % self.memory_addresses.kart_struct_size != 0:
+            return -1
+        kart_id: int = offset // self.memory_addresses.kart_struct_size
+        if kart_id >= len(game_data.KARTS):
+            return -1
+        return kart_id
+
+
     def apply_player_kart_body_stats(self) -> None:
         """Applies upgraded stats directly to the player's kart instance.
 
@@ -935,7 +950,7 @@ class MkddGameState():
         kart_ctrl: int = dolphin.read_word(self.memory_addresses.kart_control_pointer)
         kart_address: int = dolphin.read_word(kart_ctrl + self.memory_addresses.kart_control_kart_pointers_offset)
         # Make sure the kart instance is initialized and drives the kart we think it does.
-        if dolphin.read_word(kart_address + self.memory_addresses.kart_body_kart_id_w_offset) != self.active_kart.id:
+        if self.get_kart_body_kart_id(kart_address) != self.active_kart.id:
             return
         # During race init the pointer slot can briefly hold another kart's body.
         # If it drives the same kart model the id check won't catch it, which gave

--- a/mem_addresses.py
+++ b/mem_addresses.py
@@ -72,6 +72,22 @@ class MkddMemAddresses():
     """Kart's position is here from kart pointer (x, y, z)."""
     kart_velocity_fx_offset: int
     """Kart's velocity is here from kart pointer (x, y, z)."""
+    kart_body_speeds_fx_offset: int
+    """Kart instance speeds (road, sand, grass, mud), copied from stat table at race init."""
+    kart_body_acceleration_1_f_offset: int
+    """Kart instance acceleration 1, copied from stat table at race init."""
+    kart_body_acceleration_2_f_offset: int
+    """Kart instance acceleration 2, copied from stat table at race init."""
+    kart_body_mini_turbo_max_h_offset: int
+    """Kart instance mini-turbo boost duration (halfword!), 1 + stat table value."""
+    kart_body_mass_f_offset: int
+    """Kart instance mass, copied from stat table at race init."""
+    kart_body_steer_f_offset: int
+    """Kart instance steer, copied from stat table at race init."""
+    kart_body_kart_id_w_offset: int
+    """Kart id (0-20) of the kart instance."""
+    kart_body_class_b_offset: int
+    """Vehicle class (0-2) of the kart instance."""
     kart_struct_size: int
     """Use this in combination with kart_stats_pointer and stat offsets to modify karts."""
     kart_speed_on_road_f_offset: int
@@ -197,6 +213,14 @@ class MkddMemAddressesUsa(MkddMemAddresses):
     kart_control_kart_pointers_offset = 0xA0
     kart_position_fx_offset = 0x23c
     kart_velocity_fx_offset = 0x26c
+    kart_body_speeds_fx_offset = 0x3f0
+    kart_body_acceleration_1_f_offset = 0x3d4
+    kart_body_acceleration_2_f_offset = 0x51c
+    kart_body_mini_turbo_max_h_offset = 0x5a0
+    kart_body_mass_f_offset = 0x420
+    kart_body_steer_f_offset = 0x484
+    kart_body_kart_id_w_offset = 0x5a8
+    kart_body_class_b_offset = 0x5c4
 
     kart_struct_size = 0x100
     kart_speed_on_road_f_offset = 0x50

--- a/mem_addresses.py
+++ b/mem_addresses.py
@@ -86,6 +86,8 @@ class MkddMemAddresses():
     """Kart instance steer, copied from stat table at race init."""
     kart_body_kart_id_w_offset: int
     """Kart id (0-20) of the kart instance."""
+    kart_body_mynum_b_offset: int
+    """Kart number of the kart instance (0 = player)."""
     kart_body_class_b_offset: int
     """Vehicle class (0-2) of the kart instance."""
     kart_struct_size: int
@@ -220,6 +222,7 @@ class MkddMemAddressesUsa(MkddMemAddresses):
     kart_body_mass_f_offset = 0x420
     kart_body_steer_f_offset = 0x484
     kart_body_kart_id_w_offset = 0x5a8
+    kart_body_mynum_b_offset = 0x5b3
     kart_body_class_b_offset = 0x5c4
 
     kart_struct_size = 0x100

--- a/mem_addresses.py
+++ b/mem_addresses.py
@@ -84,8 +84,10 @@ class MkddMemAddresses():
     """Kart instance mass, copied from stat table at race init."""
     kart_body_steer_f_offset: int
     """Kart instance steer, copied from stat table at race init."""
-    kart_body_kart_id_w_offset: int
-    """Kart id (0-20) of the kart instance."""
+    kart_body_setting_ptr_offset: int
+    """Pointer to the kart's row in the shared stat table. The only reliable way
+    to tell which kart a body drives; the id-looking word at +0x5a8 is a different
+    index space and does not match the stat table order in grand prix."""
     kart_body_mynum_b_offset: int
     """Kart number of the kart instance (0 = player)."""
     kart_body_class_b_offset: int
@@ -221,7 +223,7 @@ class MkddMemAddressesUsa(MkddMemAddresses):
     kart_body_mini_turbo_max_h_offset = 0x5a0
     kart_body_mass_f_offset = 0x420
     kart_body_steer_f_offset = 0x484
-    kart_body_kart_id_w_offset = 0x5a8
+    kart_body_setting_ptr_offset = 0x100
     kart_body_mynum_b_offset = 0x5b3
     kart_body_class_b_offset = 0x5c4
 

--- a/patches.py
+++ b/patches.py
@@ -173,24 +173,31 @@ time_trial_items: dict[int, list[int]] = {
         0x4bd47138,
     ],
     0x800020b4: [
+        0x38800005,
+        0x88df05b3,
+        0x28060000,
+        0x4082000c,
         0x3c808000,
         0x88841041,
-        0x482b8ec4,
+        0x482b8eb4,
     ],
     0x802bafa8: [
-        0x4bd47118,
+        0x4bd47128,
     ],
-    0x800020c0: [
+    0x800020d0: [
+        0x38800005,
+        0x28050000,
+        0x4082000c,
         0x3c808000,
         0x88841042,
-        0x482b8ee4,
+        0x482b8ec8,
     ],
 }
 item_shuffle: dict[int, list[int]] = {
     0x8020cbc0: [
-        0x4bdf550c,
+        0x4bdf5528,
     ],
-    0x800020cc: [
+    0x800020e8: [
         0x90010024,
         0x28000000,
         0x40a20030,
@@ -204,22 +211,22 @@ item_shuffle: dict[int, list[int]] = {
         0x3c608000,
         0x38631043,
         0x7c6328ae,
-        0x4820aac8,
-        0x4820aac0,
+        0x4820aaac,
+        0x4820aaa4,
     ],
 }
 force_item_shuffle: dict[int, list[int]] = {
     0x80189c50: [
-        0x4be784b8,
+        0x4be784d4,
     ],
-    0x80002108: [
+    0x80002124: [
         0x38a00001,
         0x38800000,
         0x3c60803d,
         0x8063bf40,
-        0x48209515,
+        0x482094f9,
     ],
-    0x8000211c: [
+    0x80002138: [
         0x5460063f,
         0x4182003c,
         0x3ca08000,
@@ -235,18 +242,18 @@ force_item_shuffle: dict[int, list[int]] = {
         0x38800000,
         0x3c60803d,
         0x8063bf40,
-        0x482096a9,
+        0x4820968d,
     ],
-    0x8000215c: [
+    0x80002178: [
         0x7fe3fb78,
-        0x48187af4,
+        0x48187ad8,
     ],
 }
 item_box: dict[int, list[int]] = {
     0x801fbe1c: [
-        0x4be06348,
+        0x4be06364,
     ],
-    0x80002164: [
+    0x80002180: [
         0x28040000,
         0x40a20014,
         0x808300e8,
@@ -254,7 +261,7 @@ item_box: dict[int, list[int]] = {
         0x90831060,
         0x38800000,
         0x806daaa0,
-        0x481f9ca0,
+        0x481f9c84,
     ],
     0x801fb77c: [
         0x9421ffe8,
@@ -269,9 +276,9 @@ item_box: dict[int, list[int]] = {
         0x38210018,
     ],
     0x801fb78c: [
-        0x4be069f8,
+        0x4be06a14,
     ],
-    0x80002184: [
+    0x800021a0: [
         0x8183017c,
         0x2c0c0002,
         0x40820014,
@@ -279,14 +286,14 @@ item_box: dict[int, list[int]] = {
         0xbbac000c,
         0xbfa30040,
         0x7c7f1b78,
-        0x481f95f0,
+        0x481f95d4,
     ],
 }
 rolling_item_box: dict[int, list[int]] = {
     0x8027d1e4: [
-        0x4bd84fc0,
+        0x4bd84fdc,
     ],
-    0x800021a4: [
+    0x800021c0: [
         0x28040000,
         0x40a20014,
         0x808300e8,
@@ -294,7 +301,7 @@ rolling_item_box: dict[int, list[int]] = {
         0x909f1060,
         0x38800000,
         0x7c7f1b78,
-        0x4827b028,
+        0x4827b00c,
     ],
     0x8027cb1c: [
         0x9421ffe8,
@@ -309,28 +316,28 @@ rolling_item_box: dict[int, list[int]] = {
         0x38210018,
     ],
     0x8027cb2c: [
-        0x4bd85698,
+        0x4bd856b4,
     ],
-    0x800021c4: [
+    0x800021e0: [
         0x818300e8,
         0xbbac000c,
         0xbfa30040,
         0x7c7f1b78,
-        0x4827a95c,
+        0x4827a940,
     ],
 }
 car_item_box: dict[int, list[int]] = {
     0x8019a69c: [
-        0x4be67b3c,
+        0x4be67b58,
     ],
-    0x800021d8: [
+    0x800021f4: [
         0x28040000,
         0x40a20010,
         0x83c300e8,
         0x3fe08000,
         0x93df1060,
         0x7c7e1b78,
-        0x481984b0,
+        0x48198494,
     ],
     0x8019a630: [
         0x9421ffe8,
@@ -345,14 +352,14 @@ car_item_box: dict[int, list[int]] = {
         0x38210018,
     ],
     0x8019a640: [
-        0x4be67bb4,
+        0x4be67bd0,
     ],
-    0x800021f4: [
+    0x80002210: [
         0x818300e8,
         0xbbac000c,
         0xbfa30040,
         0x7c7f1b78,
-        0x48198440,
+        0x48198424,
     ],
 }
 disable_start_pos_shuffle: dict[int, list[int]] = {
@@ -362,9 +369,9 @@ disable_start_pos_shuffle: dict[int, list[int]] = {
 }
 spawn_item: dict[int, list[int]] = {
     0x80189b90: [
-        0x4be78678,
+        0x4be78694,
     ],
-    0x80002208: [
+    0x80002224: [
         0x3ca08000,
         0x8085106c,
         0x28040014,
@@ -375,9 +382,9 @@ spawn_item: dict[int, list[int]] = {
         0x38a51070,
         0x3c60803d,
         0x8063bf40,
-        0x4820706d,
+        0x48207051,
     ],
-    0x80002234: [
+    0x80002250: [
         0x28030000,
         0x41820014,
         0x38000000,
@@ -385,14 +392,14 @@ spawn_item: dict[int, list[int]] = {
         0x38000001,
         0x98030124,
         0x887f0022,
-        0x48187944,
+        0x48187928,
     ],
 }
 draw_string: dict[int, list[int]] = {
     0x801d1b58: [
-        0x4be306fc,
+        0x4be30718,
     ],
-    0x80002254: [
+    0x80002270: [
         0x9421fff0,
         0x7c0802a6,
         0x90010014,
@@ -403,9 +410,9 @@ draw_string: dict[int, list[int]] = {
         0x7ca5fa14,
         0xa065fffc,
         0xa085fffe,
-        0x480179d1,
+        0x480179b5,
     ],
-    0x80002280: [
+    0x8000229c: [
         0x3bff0030,
         0x281f00f0,
         0x4180ffe0,
@@ -414,14 +421,14 @@ draw_string: dict[int, list[int]] = {
         0x7c0803a6,
         0x38210010,
         0x80010014,
-        0x481cf8bc,
+        0x481cf8a0,
     ],
 }
 invalidate_cache: dict[int, list[int]] = {
     0x80159394: [
-        0x4bea8f10,
+        0x4bea8f2c,
     ],
-    0x800022a4: [
+    0x800022c0: [
         0x3d808016,
         0x398c38b0,
         0x7c00606c,
@@ -572,12 +579,12 @@ invalidate_cache: dict[int, list[int]] = {
         0x7c0067ac,
     ],
     0x80162308: [
-        0x4be9ff9c,
+        0x4be9ffb8,
     ],
     0x8011510c: [
-        0x4beed198,
+        0x4beed1b4,
     ],
-    0x800024f4: [
+    0x80002510: [
         0x4c00012c,
         0x4e800020,
     ],


### PR DESCRIPTION
This should take care of both desync causes from #41:

- Ghosts were getting the randomized TT items instead of the single mushroom they were recorded with. The item hooks now check the kart number and only apply to kart 0, so ghosts get their vanilla mushroom back.
- Kart upgrades (and the engine speed multiplier) are baked into the shared kart stat table, so a ghost using the same kart inherited them. In time trials the table now stays vanilla and the player upgrades get written straight into the kart instance fields instead (the ones that get copied from the table at race init). Basically the "correct way" mentioned in #42, though I only did it for TT so the GP rival behaviour stays as it is.

Own ghosts that were recorded with different upgrades will still desync, fixing that would need storing the conditions in the ghost data somehow. Staff ghosts should be fully in sync now though.

I checked the patched code against a disassembly of the retail dol and against the memory of a running game, but more testing is very welcome.

Fixes #41